### PR TITLE
Add share feature for donation

### DIFF
--- a/hamsa_lomi/android/app/src/main/AndroidManifest.xml
+++ b/hamsa_lomi/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,13 @@
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
+
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:host="hamsalomi.com" android:scheme="https" />
+      </intent-filter>
     </activity>
 
     <activity android:name="com.yalantis.ucrop.UCropActivity" android:screenOrientation="portrait" android:theme="@style/Theme.AppCompat.Light.NoActionBar" />

--- a/hamsa_lomi/lib/presentation/core/widgets/hamsa_app_bar.dart
+++ b/hamsa_lomi/lib/presentation/core/widgets/hamsa_app_bar.dart
@@ -13,9 +13,14 @@ class HamsaAppBar extends StatelessWidget implements PreferredSizeWidget {
   final bool withLogo;
   final bool withLeading;
   final Text? appBarText;
+  final Widget? actionButton;
 
-  const HamsaAppBar(
-      {this.appBarText, required this.withLogo, required this.withLeading});
+  const HamsaAppBar({
+    this.appBarText,
+    required this.withLogo,
+    required this.withLeading,
+    this.actionButton,
+  });
 
   @override
   Size get preferredSize => Size.fromHeight(kToolbarHeight + 10);
@@ -31,42 +36,51 @@ class HamsaAppBar extends StatelessWidget implements PreferredSizeWidget {
           title: appBarText,
           automaticallyImplyLeading: false,
           leading: withLeading
-              ? Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: Container(
-                    // color: HamsaColors.primaryColor,
-                    // margin: EdgeInsets.only(left: 2,),
-                    decoration: BoxDecoration(
-                      border: Border.all(
-                        color: HamsaColors.lightGray,
-                      ),
-                      // color: HamsaColors.lightGray,
-                      borderRadius: BorderRadius.circular(15.0),
-                    ),
-                    child: IconButton(
-                      // color: Colors.transparent,
-                      // padding: EdgeInsets.zero,
-                      icon: Icon(Icons.arrow_back),
-                      onPressed: () {
-                        Navigator.maybePop(context);
-                      },
-                    ),
+              ? _OutlinedIconButton(
+                  child: IconButton(
+                    icon: Icon(Icons.arrow_back),
+                    onPressed: () {
+                      Navigator.maybePop(context);
+                    },
                   ),
                 )
               : null,
-          actions: [
-            withLogo
-                ? Padding(
+          actions: withLogo
+              ? [
+                  Padding(
                     padding: const EdgeInsets.all(8.0),
                     child: SvgPicture.asset(
                       HamsaIcons.hamsaLogo,
                     ),
                   )
-                : Container(),
-          ],
+                ]
+              : actionButton != null
+                  ? [_OutlinedIconButton(child: actionButton!)]
+                  : null,
         ),
       ),
-      preferredSize: Size.fromHeight(kToolbarHeight + 10),
+      preferredSize: Size.fromHeight(kToolbarHeight),
+    );
+  }
+}
+
+class _OutlinedIconButton extends StatelessWidget {
+  final Widget child;
+  const _OutlinedIconButton({Key? key, required this.child}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: HamsaColors.lightGray,
+          ),
+          borderRadius: BorderRadius.circular(15.0),
+        ),
+        child: child,
+      ),
     );
   }
 }

--- a/hamsa_lomi/lib/presentation/core/widgets/hamsa_campaign_card.dart
+++ b/hamsa_lomi/lib/presentation/core/widgets/hamsa_campaign_card.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/widgets.dart';
+import '../../hamsa_campaign_detail/page/hamsa_campaign_detail_page.dart';
 
 // Project imports:
 import '../../../domain/core/entities/entities.dart';
@@ -14,48 +15,54 @@ class HamsaCampaignCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Container(
-          clipBehavior: Clip.antiAlias,
-          height: 202,
-          decoration: BoxDecoration(borderRadius: BorderRadius.circular(20.0)),
-          child: Stack(
-            children: [
-              Image.network(
-                campaign.imageGallery.first,
-                fit: BoxFit.cover,
-                width: double.maxFinite,
-              ),
-              Positioned(
-                top: 16,
-                right: 16,
-                child: _DaysLeft(
-                  remainingDays: campaign.remainingDays,
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(context, HamsaCampaignDetailPage.route(campaign));
+      },
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Container(
+            clipBehavior: Clip.antiAlias,
+            height: 202,
+            decoration:
+                BoxDecoration(borderRadius: BorderRadius.circular(20.0)),
+            child: Stack(
+              children: [
+                Image.network(
+                  campaign.imageGallery.first,
+                  fit: BoxFit.cover,
+                  width: double.maxFinite,
                 ),
-              ),
-              Positioned(
-                left: 16,
-                right: 16,
-                bottom: 16,
-                child: _RaisedAmount(
-                  campaign: campaign,
+                Positioned(
+                  top: 16,
+                  right: 16,
+                  child: _DaysLeft(
+                    remainingDays: campaign.remainingDays,
+                  ),
                 ),
-              )
-            ],
+                Positioned(
+                  left: 16,
+                  right: 16,
+                  bottom: 16,
+                  child: _RaisedAmount(
+                    campaign: campaign,
+                  ),
+                )
+              ],
+            ),
           ),
-        ),
-        SizedBox(
-          height: 4.0,
-        ),
-        Text(
-          campaign.title,
-          style: TextStyle(
-            fontWeight: FontWeight.w600,
+          SizedBox(
+            height: 4.0,
           ),
-        )
-      ],
+          Text(
+            campaign.title,
+            style: TextStyle(
+              fontWeight: FontWeight.w600,
+            ),
+          )
+        ],
+      ),
     );
   }
 }

--- a/hamsa_lomi/lib/presentation/hamsa_campaign_detail/page/hamsa_campaign_detail_page.dart
+++ b/hamsa_lomi/lib/presentation/hamsa_campaign_detail/page/hamsa_campaign_detail_page.dart
@@ -1,8 +1,13 @@
-import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
+// Flutter imports:
 import 'package:flutter/material.dart';
-import '../../core/widgets/hamsa_app_bar.dart';
-import '../../../domain/core/entities/entities.dart';
+
+// Package imports:
+import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
 import 'package:share_plus/share_plus.dart';
+
+// Project imports:
+import '../../../domain/core/entities/entities.dart';
+import '../../core/widgets/hamsa_app_bar.dart';
 
 class HamsaCampaignDetailPage extends StatelessWidget {
   final HamsaCampaign campaign;

--- a/hamsa_lomi/lib/presentation/hamsa_campaign_detail/page/hamsa_campaign_detail_page.dart
+++ b/hamsa_lomi/lib/presentation/hamsa_campaign_detail/page/hamsa_campaign_detail_page.dart
@@ -1,9 +1,12 @@
+import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
 import 'package:flutter/material.dart';
 import '../../core/widgets/hamsa_app_bar.dart';
 import '../../../domain/core/entities/entities.dart';
+import 'package:share_plus/share_plus.dart';
 
 class HamsaCampaignDetailPage extends StatelessWidget {
   final HamsaCampaign campaign;
+  final FirebaseDynamicLinks dynamicLinks = FirebaseDynamicLinks.instance;
 
   static MaterialPageRoute route(HamsaCampaign campaign) {
     return MaterialPageRoute(
@@ -13,8 +16,7 @@ class HamsaCampaignDetailPage extends StatelessWidget {
     );
   }
 
-  const HamsaCampaignDetailPage({Key? key, required this.campaign})
-      : super(key: key);
+  HamsaCampaignDetailPage({Key? key, required this.campaign}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -25,9 +27,23 @@ class HamsaCampaignDetailPage extends StatelessWidget {
         appBarText: Text('Fundraiser'),
         actionButton: IconButton(
           icon: Icon(Icons.share_rounded),
-          onPressed: () {},
+          onPressed: _handleSharing,
         ),
       ),
     );
+  }
+
+  void _handleSharing() async {
+    final parameters = DynamicLinkParameters(
+      uriPrefix: 'https://lomi.page.link',
+      link: Uri.parse('https://hamsalomi.com/campaign/${campaign.id}'),
+      androidParameters: AndroidParameters(
+        packageName: 'org.hamsa.lomi',
+      ),
+    );
+
+    final uri = await dynamicLinks.buildLink(parameters);
+
+    Share.share(uri.toString());
   }
 }

--- a/hamsa_lomi/lib/presentation/hamsa_campaign_detail/page/hamsa_campaign_detail_page.dart
+++ b/hamsa_lomi/lib/presentation/hamsa_campaign_detail/page/hamsa_campaign_detail_page.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import '../../core/widgets/hamsa_app_bar.dart';
+import '../../../domain/core/entities/entities.dart';
+
+class HamsaCampaignDetailPage extends StatelessWidget {
+  final HamsaCampaign campaign;
+
+  static MaterialPageRoute route(HamsaCampaign campaign) {
+    return MaterialPageRoute(
+      builder: (_) => HamsaCampaignDetailPage(
+        campaign: campaign,
+      ),
+    );
+  }
+
+  const HamsaCampaignDetailPage({Key? key, required this.campaign})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: HamsaAppBar(
+        withLogo: false,
+        withLeading: true,
+        appBarText: Text('Fundraiser'),
+        actionButton: IconButton(
+          icon: Icon(Icons.share_rounded),
+          onPressed: () {},
+        ),
+      ),
+    );
+  }
+}

--- a/hamsa_lomi/pubspec.lock
+++ b/hamsa_lomi/pubspec.lock
@@ -294,7 +294,7 @@ packages:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.3"
+    version: "4.2.4"
   firebase_core_web:
     dependency: transitive
     description:
@@ -302,6 +302,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.3"
+  firebase_dynamic_links:
+    dependency: "direct main"
+    description:
+      name: firebase_dynamic_links
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.5"
+  firebase_dynamic_links_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_dynamic_links_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0+5"
   firebase_storage:
     dependency: "direct main"
     description:
@@ -632,6 +646,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.4"
+  share_plus_linux:
+    dependency: transitive
+    description:
+      name: share_plus_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  share_plus_macos:
+    dependency: transitive
+    description:
+      name: share_plus_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  share_plus_web:
+    dependency: transitive
+    description:
+      name: share_plus_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  share_plus_windows:
+    dependency: transitive
+    description:
+      name: share_plus_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
   shelf:
     dependency: transitive
     description:
@@ -742,6 +798,62 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  url_launcher:
+    dependency: transitive
+    description:
+      name: url_launcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.18"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.14"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.14"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.7"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
   vector_math:
     dependency: transitive
     description:

--- a/hamsa_lomi/pubspec.yaml
+++ b/hamsa_lomi/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   file_picker: ^4.3.1
   firebase_auth: ^3.1.0
   firebase_core: ^1.6.0
+  firebase_dynamic_links: ^4.0.5
   firebase_storage: ^10.2.4
   flutter:
     sdk: flutter
@@ -45,6 +46,7 @@ dependencies:
   intl_phone_field: ^2.0.1
   json_annotation: ^4.4.0
   mockito: ^5.0.10
+  share_plus: ^3.0.4
   sms_autofill: ^2.0.1
 
 dev_dependencies:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Added a share button inside a donation campaign detail page. When the share button is pressed the native share window is opened. Users can copy the link or send it using one of their installed apps. 

Fixes #78 

## Type of change
<!-- Please delete options that are not relevant. -->
<!--- Put an `x` in all the boxes that apply: -->
- [x] ✨ New feature (non-breaking change which adds functionality)

## Screenshots

![Screenshot_1644381653](https://user-images.githubusercontent.com/25957442/153123419-afb0f50f-2b30-4ac5-8999-3f533b9d953e.png)
![Screenshot_1644381647](https://user-images.githubusercontent.com/25957442/153123403-d468d0eb-4503-412a-a368-1e52a6e09e28.png)

