### PR TITLE
Add cover photo to campaign

### DIFF
--- a/hamsa_lomi/lib/data/core/models/hamsa_campaign_model.dart
+++ b/hamsa_lomi/lib/data/core/models/hamsa_campaign_model.dart
@@ -16,6 +16,7 @@ class HamsaCampaignModel extends HamsaCampaign {
     required DateTime dueDate,
     required List<String> imageGallery,
     required String id,
+    required String coverPhoto,
     double? amountRaised,
   }) : super(
           title: title,
@@ -25,7 +26,8 @@ class HamsaCampaignModel extends HamsaCampaign {
           dueDate: dueDate,
           id: id,
           imageGallery: imageGallery,
-          amountRaised: amountRaised ?? 0
+          amountRaised: amountRaised ?? 0,
+          coverPhoto: coverPhoto,
         );
 
   factory HamsaCampaignModel.fromJson(Map<String, dynamic> json) =>

--- a/hamsa_lomi/lib/data/core/models/hamsa_campaign_model.g.dart
+++ b/hamsa_lomi/lib/data/core/models/hamsa_campaign_model.g.dart
@@ -17,6 +17,7 @@ HamsaCampaignModel _$HamsaCampaignModelFromJson(Map<String, dynamic> json) =>
           .map((e) => e as String)
           .toList(),
       id: json['id'] as String,
+      coverPhoto: json['coverPhoto'] as String,
       amountRaised: (json['amountRaised'] as num?)?.toDouble(),
     );
 
@@ -28,6 +29,7 @@ Map<String, dynamic> _$HamsaCampaignModelToJson(HamsaCampaignModel instance) =>
       'description': instance.description,
       'dueDate': instance.dueDate.toIso8601String(),
       'imageGallery': instance.imageGallery,
+      'coverPhoto': instance.coverPhoto,
       'id': instance.id,
       'amountRaised': instance.amountRaised,
     };

--- a/hamsa_lomi/lib/data/donation_creation/models/create_hamsa_campaign_model.dart
+++ b/hamsa_lomi/lib/data/donation_creation/models/create_hamsa_campaign_model.dart
@@ -19,6 +19,7 @@ class CreateHamsaCampaignModel extends CreateHamsaCampaign {
     required String description,
     required DateTime dueDate,
     required List<String> imageGallery,
+    required String coverPhoto,
     final String? videoAttachment,
     final String? documentAttachment,
   }) : super(
@@ -30,6 +31,7 @@ class CreateHamsaCampaignModel extends CreateHamsaCampaign {
           imageGallery: imageGallery,
           documentAttachment: documentAttachment,
           videoAttachment: videoAttachment,
+          coverPhoto: coverPhoto,
         );
 
   static CreateHamsaCampaignModel toModel(CreateHamsaCampaign entity) {
@@ -42,6 +44,7 @@ class CreateHamsaCampaignModel extends CreateHamsaCampaign {
       imageGallery: entity.imageGallery,
       documentAttachment: entity.documentAttachment,
       videoAttachment: entity.videoAttachment,
+      coverPhoto: entity.coverPhoto,
     );
   }
 

--- a/hamsa_lomi/lib/data/donation_creation/models/create_hamsa_campaign_model.g.dart
+++ b/hamsa_lomi/lib/data/donation_creation/models/create_hamsa_campaign_model.g.dart
@@ -17,6 +17,7 @@ CreateHamsaCampaignModel _$CreateHamsaCampaignModelFromJson(
       imageGallery: (json['imageGallery'] as List<dynamic>)
           .map((e) => e as String)
           .toList(),
+      coverPhoto: json['coverPhoto'] as String,
       videoAttachment: json['videoAttachment'] as String?,
       documentAttachment: json['documentAttachment'] as String?,
     );
@@ -29,6 +30,7 @@ Map<String, dynamic> _$CreateHamsaCampaignModelToJson(
       'description': instance.description,
       'dueDate': instance.dueDate.toIso8601String(),
       'imageGallery': instance.imageGallery,
+      'coverPhoto': instance.coverPhoto,
       'videoAttachment': instance.videoAttachment,
       'documentAttachment': instance.documentAttachment,
       'category':

--- a/hamsa_lomi/lib/domain/core/entities/base_hamsa_campaign.dart
+++ b/hamsa_lomi/lib/domain/core/entities/base_hamsa_campaign.dart
@@ -11,6 +11,7 @@ abstract class BaseHamsaCampaign extends Equatable {
   final String description;
   final DateTime dueDate;
   final List<String> imageGallery;
+  final String coverPhoto;
   final String? videoAttachment;
   final String? documentAttachment;
 
@@ -21,6 +22,7 @@ abstract class BaseHamsaCampaign extends Equatable {
     required this.description,
     required this.dueDate,
     required this.imageGallery,
+    required this.coverPhoto,
     this.videoAttachment,
     this.documentAttachment,
   });
@@ -34,6 +36,7 @@ abstract class BaseHamsaCampaign extends Equatable {
         dueDate,
         imageGallery,
         videoAttachment,
-        documentAttachment
+        documentAttachment,
+        coverPhoto,
       ];
 }

--- a/hamsa_lomi/lib/domain/core/entities/hamsa_campaign.dart
+++ b/hamsa_lomi/lib/domain/core/entities/hamsa_campaign.dart
@@ -12,6 +12,7 @@ class HamsaCampaign extends BaseHamsaCampaign {
     required String description,
     required DateTime dueDate,
     required List<String> imageGallery,
+    required String coverPhoto,
     final String? videoAttachment,
     final String? documentAttachment,
     required this.id,
@@ -25,6 +26,7 @@ class HamsaCampaign extends BaseHamsaCampaign {
           imageGallery: imageGallery,
           videoAttachment: videoAttachment,
           documentAttachment: documentAttachment,
+          coverPhoto: coverPhoto,
         );
 
   @override

--- a/hamsa_lomi/lib/domain/donation_creation/entities/create_hamsa_campaign.dart
+++ b/hamsa_lomi/lib/domain/donation_creation/entities/create_hamsa_campaign.dart
@@ -9,6 +9,7 @@ class CreateHamsaCampaign extends BaseHamsaCampaign {
     required String description,
     required DateTime dueDate,
     required List<String> imageGallery,
+    required String coverPhoto,
     final String? videoAttachment,
     final String? documentAttachment,
   }) : super(
@@ -20,6 +21,7 @@ class CreateHamsaCampaign extends BaseHamsaCampaign {
           imageGallery: imageGallery,
           videoAttachment: videoAttachment,
           documentAttachment: documentAttachment,
+          coverPhoto: coverPhoto,
         );
 
   @override

--- a/hamsa_lomi/lib/presentation/core/widgets/hamsa_campaign_card.dart
+++ b/hamsa_lomi/lib/presentation/core/widgets/hamsa_campaign_card.dart
@@ -30,7 +30,7 @@ class HamsaCampaignCard extends StatelessWidget {
             child: Stack(
               children: [
                 Image.network(
-                  campaign.imageGallery.first,
+                  campaign.coverPhoto,
                   fit: BoxFit.cover,
                   width: double.maxFinite,
                 ),

--- a/hamsa_lomi/lib/presentation/donation_creation/bloc/donation_creation/donation_creation_bloc.dart
+++ b/hamsa_lomi/lib/presentation/donation_creation/bloc/donation_creation/donation_creation_bloc.dart
@@ -26,66 +26,61 @@ class DonationCreationBloc
     on<TitleChanged>((event, emit) {
       final titleInput = RequiredTextInput.dirty(event.title);
       final status = _validateFormInputs(
-        title: titleInput,
-        description: state.description,
-        category: state.category,
-        goal: state.goal,
-        dueDate: state.dueDate,
-        imageGallery: state.imageGallery,
-        coverPhoto: state.coverPhoto
-      );
+          title: titleInput,
+          description: state.description,
+          category: state.category,
+          goal: state.goal,
+          dueDate: state.dueDate,
+          imageGallery: state.imageGallery,
+          coverPhoto: state.coverPhoto);
       emit(state.copyWith(title: titleInput, status: status));
     });
     on<DescriptionChanged>((event, emit) {
       final descriptionInput = RequiredTextInput.dirty(event.description);
       final status = _validateFormInputs(
-        title: state.title,
-        description: descriptionInput,
-        category: state.category,
-        goal: state.goal,
-        dueDate: state.dueDate,
-        imageGallery: state.imageGallery,
-        coverPhoto: state.coverPhoto
-      );
+          title: state.title,
+          description: descriptionInput,
+          category: state.category,
+          goal: state.goal,
+          dueDate: state.dueDate,
+          imageGallery: state.imageGallery,
+          coverPhoto: state.coverPhoto);
       emit(state.copyWith(description: descriptionInput, status: status));
     });
     on<CategoryChanged>((event, emit) {
       final categoryInput = RequiredCategoryInput.dirty(event.category);
       final status = _validateFormInputs(
-        title: state.title,
-        description: state.description,
-        category: categoryInput,
-        goal: state.goal,
-        dueDate: state.dueDate,
-        imageGallery: state.imageGallery,
-        coverPhoto: state.coverPhoto
-      );
+          title: state.title,
+          description: state.description,
+          category: categoryInput,
+          goal: state.goal,
+          dueDate: state.dueDate,
+          imageGallery: state.imageGallery,
+          coverPhoto: state.coverPhoto);
       emit(state.copyWith(category: categoryInput, status: status));
     });
     on<GoalAmountChanged>((event, emit) {
       final goalInput = RequiredGoalInput.dirty(event.goal);
       final status = _validateFormInputs(
-        category: state.category,
-        description: state.description,
-        goal: goalInput,
-        title: state.title,
-        dueDate: state.dueDate,
-        imageGallery: state.imageGallery,
-        coverPhoto: state.coverPhoto
-      );
+          category: state.category,
+          description: state.description,
+          goal: goalInput,
+          title: state.title,
+          dueDate: state.dueDate,
+          imageGallery: state.imageGallery,
+          coverPhoto: state.coverPhoto);
       emit(state.copyWith(status: status, goal: goalInput));
     });
     on<DueDateChanged>((event, emit) {
       final dueDateInput = RequiredDueDateInput.dirty(event.dueDate);
       final status = _validateFormInputs(
-        title: state.title,
-        description: state.description,
-        category: state.category,
-        goal: state.goal,
-        dueDate: dueDateInput,
-        imageGallery: state.imageGallery,
-        coverPhoto: state.coverPhoto
-      );
+          title: state.title,
+          description: state.description,
+          category: state.category,
+          goal: state.goal,
+          dueDate: dueDateInput,
+          imageGallery: state.imageGallery,
+          coverPhoto: state.coverPhoto);
       emit(state.copyWith(status: status, dueDate: dueDateInput));
     });
     on<ImageGalleryUpdated>((event, emit) async {
@@ -94,28 +89,26 @@ class DonationCreationBloc
         event.downloadUrl,
       ]);
       final status = _validateFormInputs(
-        title: state.title,
-        description: state.description,
-        category: state.category,
-        goal: state.goal,
-        dueDate: state.dueDate,
-        imageGallery: imageGalleryInput,
-        coverPhoto: state.coverPhoto
-      );
+          title: state.title,
+          description: state.description,
+          category: state.category,
+          goal: state.goal,
+          dueDate: state.dueDate,
+          imageGallery: imageGalleryInput,
+          coverPhoto: state.coverPhoto);
       emit(state.copyWith(status: status, imageGallery: imageGalleryInput));
     });
     on<ImageRemoved>((event, emit) async {
       final modifiedList = [...state.imageGallery.value]..removeAt(event.index);
       final imageGalleryInput = ImageGalleryInput.dirty(modifiedList);
       final status = _validateFormInputs(
-        title: state.title,
-        description: state.description,
-        category: state.category,
-        goal: state.goal,
-        dueDate: state.dueDate,
-        imageGallery: imageGalleryInput,
-        coverPhoto: state.coverPhoto
-      );
+          title: state.title,
+          description: state.description,
+          category: state.category,
+          goal: state.goal,
+          dueDate: state.dueDate,
+          imageGallery: imageGalleryInput,
+          coverPhoto: state.coverPhoto);
       emit(state.copyWith(status: status, imageGallery: imageGalleryInput));
     });
     on<VideoAttachmentAdded>((event, emit) {
@@ -124,8 +117,11 @@ class DonationCreationBloc
     on<DocumentAttachmentAdded>((event, emit) {
       emit(state.copyWith(documentAttachment: event.downloadUrl));
     });
-    on<CoverPhotoAdded>((event, emit) async {
-      final coverPhotoInput = RequiredTextInput.dirty(event.coverPhoto);
+    on<CoverPhotoModified>((event, emit) async {
+      final coverPhotoInput = event.coverPhoto == null
+          ? RequiredTextInput.pure()
+          : RequiredTextInput.dirty(event.coverPhoto!);
+
       final status = _validateFormInputs(
           title: state.title,
           description: state.description,

--- a/hamsa_lomi/lib/presentation/donation_creation/bloc/donation_creation/donation_creation_bloc.dart
+++ b/hamsa_lomi/lib/presentation/donation_creation/bloc/donation_creation/donation_creation_bloc.dart
@@ -32,6 +32,7 @@ class DonationCreationBloc
         goal: state.goal,
         dueDate: state.dueDate,
         imageGallery: state.imageGallery,
+        coverPhoto: state.coverPhoto
       );
       emit(state.copyWith(title: titleInput, status: status));
     });
@@ -44,6 +45,7 @@ class DonationCreationBloc
         goal: state.goal,
         dueDate: state.dueDate,
         imageGallery: state.imageGallery,
+        coverPhoto: state.coverPhoto
       );
       emit(state.copyWith(description: descriptionInput, status: status));
     });
@@ -56,6 +58,7 @@ class DonationCreationBloc
         goal: state.goal,
         dueDate: state.dueDate,
         imageGallery: state.imageGallery,
+        coverPhoto: state.coverPhoto
       );
       emit(state.copyWith(category: categoryInput, status: status));
     });
@@ -68,6 +71,7 @@ class DonationCreationBloc
         title: state.title,
         dueDate: state.dueDate,
         imageGallery: state.imageGallery,
+        coverPhoto: state.coverPhoto
       );
       emit(state.copyWith(status: status, goal: goalInput));
     });
@@ -80,6 +84,7 @@ class DonationCreationBloc
         goal: state.goal,
         dueDate: dueDateInput,
         imageGallery: state.imageGallery,
+        coverPhoto: state.coverPhoto
       );
       emit(state.copyWith(status: status, dueDate: dueDateInput));
     });
@@ -95,6 +100,7 @@ class DonationCreationBloc
         goal: state.goal,
         dueDate: state.dueDate,
         imageGallery: imageGalleryInput,
+        coverPhoto: state.coverPhoto
       );
       emit(state.copyWith(status: status, imageGallery: imageGalleryInput));
     });
@@ -108,6 +114,7 @@ class DonationCreationBloc
         goal: state.goal,
         dueDate: state.dueDate,
         imageGallery: imageGalleryInput,
+        coverPhoto: state.coverPhoto
       );
       emit(state.copyWith(status: status, imageGallery: imageGalleryInput));
     });
@@ -116,6 +123,18 @@ class DonationCreationBloc
     });
     on<DocumentAttachmentAdded>((event, emit) {
       emit(state.copyWith(documentAttachment: event.downloadUrl));
+    });
+    on<CoverPhotoAdded>((event, emit) async {
+      final coverPhotoInput = RequiredTextInput.dirty(event.coverPhoto);
+      final status = _validateFormInputs(
+          title: state.title,
+          description: state.description,
+          category: state.category,
+          goal: state.goal,
+          dueDate: state.dueDate,
+          imageGallery: state.imageGallery,
+          coverPhoto: coverPhotoInput);
+      emit(state.copyWith(status: status, coverPhoto: coverPhotoInput));
     });
     on<DonationCreationFormSubmitted>((event, emit) async {
       if (state.status.isValidated) {
@@ -131,6 +150,7 @@ class DonationCreationBloc
             imageGallery: state.imageGallery.value,
             documentAttachment: state.documentAttachment,
             videoAttachment: state.videoAttachment,
+            coverPhoto: state.coverPhoto.value,
           ),
         );
 
@@ -144,6 +164,7 @@ class DonationCreationBloc
   FormzStatus _validateFormInputs({
     required RequiredTextInput title,
     required RequiredTextInput description,
+    required RequiredTextInput coverPhoto,
     required RequiredCategoryInput category,
     required RequiredGoalInput goal,
     required RequiredDueDateInput dueDate,
@@ -156,6 +177,7 @@ class DonationCreationBloc
       goal,
       dueDate,
       imageGallery,
+      coverPhoto
     ]);
   }
 }

--- a/hamsa_lomi/lib/presentation/donation_creation/bloc/donation_creation/donation_creation_event.dart
+++ b/hamsa_lomi/lib/presentation/donation_creation/bloc/donation_creation/donation_creation_event.dart
@@ -89,3 +89,12 @@ class DonationCreationFormSubmitted extends DonationCreationEvent {
   @override
   List<Object?> get props => [];
 }
+
+class CoverPhotoAdded extends DonationCreationEvent {
+  final String coverPhoto;
+
+  CoverPhotoAdded(this.coverPhoto);
+
+  @override
+  List<Object?> get props => [coverPhoto];
+}

--- a/hamsa_lomi/lib/presentation/donation_creation/bloc/donation_creation/donation_creation_event.dart
+++ b/hamsa_lomi/lib/presentation/donation_creation/bloc/donation_creation/donation_creation_event.dart
@@ -90,10 +90,10 @@ class DonationCreationFormSubmitted extends DonationCreationEvent {
   List<Object?> get props => [];
 }
 
-class CoverPhotoAdded extends DonationCreationEvent {
-  final String coverPhoto;
+class CoverPhotoModified extends DonationCreationEvent {
+  final String? coverPhoto;
 
-  CoverPhotoAdded(this.coverPhoto);
+  CoverPhotoModified(this.coverPhoto);
 
   @override
   List<Object?> get props => [coverPhoto];

--- a/hamsa_lomi/lib/presentation/donation_creation/bloc/donation_creation/donation_creation_state.dart
+++ b/hamsa_lomi/lib/presentation/donation_creation/bloc/donation_creation/donation_creation_state.dart
@@ -3,6 +3,7 @@ part of 'donation_creation_bloc.dart';
 class DonationCreationState extends Equatable {
   final RequiredTextInput title;
   final RequiredTextInput description;
+  final RequiredTextInput coverPhoto;
   final RequiredCategoryInput category;
   final RequiredGoalInput goal;
   final RequiredDueDateInput dueDate;
@@ -19,6 +20,7 @@ class DonationCreationState extends Equatable {
     this.goal = const RequiredGoalInput.pure(),
     this.dueDate = const RequiredDueDateInput.pure(),
     this.imageGallery = const ImageGalleryInput.pure(),
+    this.coverPhoto = const RequiredTextInput.pure(),
     this.videoAttachment,
     this.documentAttachment,
     this.status = FormzStatus.pure,
@@ -34,7 +36,8 @@ class DonationCreationState extends Equatable {
         dueDate,
         imageGallery,
         videoAttachment,
-        documentAttachment
+        documentAttachment,
+        coverPhoto
       ];
 
   DonationCreationState copyWith({
@@ -43,6 +46,7 @@ class DonationCreationState extends Equatable {
     RequiredCategoryInput? category,
     RequiredGoalInput? goal,
     RequiredDueDateInput? dueDate,
+    RequiredTextInput? coverPhoto,
     ImageGalleryInput? imageGallery,
     String? documentAttachment,
     String? videoAttachment,
@@ -58,6 +62,7 @@ class DonationCreationState extends Equatable {
       imageGallery: imageGallery ?? this.imageGallery,
       documentAttachment: documentAttachment ?? this.documentAttachment,
       videoAttachment: videoAttachment ?? this.videoAttachment,
+      coverPhoto: coverPhoto ?? this.coverPhoto,
     );
   }
 }

--- a/hamsa_lomi/lib/presentation/donation_creation/widgets/donation_creation_form.dart
+++ b/hamsa_lomi/lib/presentation/donation_creation/widgets/donation_creation_form.dart
@@ -40,6 +40,7 @@ class DonationCreationForm extends StatelessWidget {
                 style: Theme.of(context).textTheme.headline5,
               ),
               _TitleInput(),
+              _CoverPhotoInput(),
               _CategoryInput(),
               _GoalInput(),
               _DescriptionInput(),
@@ -425,6 +426,32 @@ class _AddDocumentInputState extends State<_AddDocumentInput> {
                 child: Text('ADD'),
               ),
             ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _CoverPhotoInput extends StatelessWidget {
+  const _CoverPhotoInput({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return CreationFormField(
+      label: 'Cover Photo',
+      child: BlocBuilder<DonationCreationBloc, DonationCreationState>(
+        builder: (context, state) {
+          return ImageUploader(
+            onUploadSuccess: (img) {
+              context.read<DonationCreationBloc>().add(CoverPhotoModified(img));
+            },
+            onImageRemove: (_) {
+              context
+                  .read<DonationCreationBloc>()
+                  .add(CoverPhotoModified(null));
+            },
+            maxImages: 1,
           );
         },
       ),

--- a/hamsa_lomi/lib/presentation/donation_creation/widgets/image_uploader.dart
+++ b/hamsa_lomi/lib/presentation/donation_creation/widgets/image_uploader.dart
@@ -22,10 +22,14 @@ final borderRadius = BorderRadius.circular(16);
 class ImageUploader extends StatefulWidget {
   final ValueChanged<String> onUploadSuccess;
   final ValueChanged<int> onImageRemove;
+  final int maxImages;
 
-  const ImageUploader(
-      {Key? key, required this.onUploadSuccess, required this.onImageRemove})
-      : super(key: key);
+  const ImageUploader({
+    Key? key,
+    required this.onUploadSuccess,
+    required this.onImageRemove,
+    this.maxImages = 4,
+  }) : super(key: key);
 
   @override
   State<ImageUploader> createState() => _ImageUploaderState();
@@ -33,7 +37,6 @@ class ImageUploader extends StatefulWidget {
 
 class _ImageUploaderState extends State<ImageUploader> {
   final _images = <File>[];
-  final maxImages = 4;
 
   @override
   Widget build(BuildContext context) {
@@ -59,7 +62,7 @@ class _ImageUploaderState extends State<ImageUploader> {
               ),
             )
             .toList(),
-        if (_images.length < maxImages)
+        if (_images.length < widget.maxImages)
           InkWell(
             onTap: () => _showDialog(context),
             child: Container(


### PR DESCRIPTION
# Description
Add cover photo field to the donation creation form. Users are now required to upload a cover photo when creating a donation campaign.

Fixes #77 

## Type of change

<!-- Please delete options that are not relevant. -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)

## Screenshots

<!-- Please add screenshots of your work if any. -->
![Screenshot_1644672962](https://user-images.githubusercontent.com/25957442/153713660-cc020003-8459-4b6b-bbb8-256915c32764.png)

